### PR TITLE
修正 CLI help 输出中的脚本名称，从 `deepv` 改为 `dvcode`

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -84,7 +84,7 @@ export interface CliArgs {
 
 export async function parseArguments(extensions: Extension[] = []): Promise<CliArgs> {
   const yargsInstance = yargs(hideBin(process.argv))
-    .scriptName('deepv')
+    .scriptName('dvcode')
     .usage(
       '$0 [options]',
       'DeepV Code - Launch an interactive CLI, use -p/--prompt for non-interactive mode',


### PR DESCRIPTION
## Summary / 摘要

- 修正 CLI help 输出中的脚本名称，从 `deepv` 改为 `dvcode`
  Fix script name in CLI help output from `deepv` to `dvcode`.

## Changes / 变更说明

- `packages/cli/src/config/config.ts`

## Testing / 测试

执行 `dvcode --help`，第一行 dvcode [options]，Commands 里都变成了 dvcode。