### PR TITLE
fix(core): 修复 replaceAll 特殊替换模式导致文件内容损坏的问题

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -177,7 +177,7 @@ Expectation for required parameters:
       // If oldString is empty and it's not a new file, do not modify the content.
       result = currentContent;
     } else {
-      result = currentContent.replaceAll(oldString, newString);
+      result = currentContent.replaceAll(oldString, () => newString);
     }
 
     // 应用语言感知的后处理


### PR DESCRIPTION
## Summary / 摘要

- 修复 `replace` 工具中 `replaceAll` 特殊替换模式导致文件内容静默损坏的问题。Fix `replace` tool corrupting file content due to JS `replaceAll` special replacement patterns.

## Changes / 变更说明

- `packages/core/src/tools/edit.ts`

## Testing / 测试

构造包含 `$'` 的 `new_string`（如 `return '$' + price + ' ' + unit`）触发 `replace` 工具调用，验证文件内容与 `new_string` 完全一致，不再出现截断或内容错位情况。
