### PR TITLE
fix: 工具调用失败时回传错误给 AI，不再直接退出

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -271,11 +271,16 @@ export async function runNonInteractive(
                 }
                 if (!isToolNotFound) {
                   failedToolCount++;
-                  if (failedToolCount > 2 && !modelCapabilities.enableProgressiveDegradation) {
-                    process.exit(1);
-                  }
                 }
-                return null;
+                // Return the error as a functionResponse so the AI can see it and retry
+                return {
+                  responseParts: [{
+                    functionResponse: {
+                      name: fc.name ?? '',
+                      response: { error: resultDisplay },
+                    },
+                  }],
+                } as any;
               }
 
               return toolResponse;
@@ -338,14 +343,8 @@ export async function runNonInteractive(
           }
         }
 
-        if (toolResponseParts.length === 0 && failedToolCount > 0) {
-          if (outputFormat === 'stream-json') {
-            outputError('All tool calls failed. Exiting.');
-          } else {
-            console.error('\n❌ All tool calls failed. Exiting.');
-          }
-          process.exit(1);
-        }
+        // Note: tool failures are returned as functionResponse errors so the AI
+        // can see them and retry with corrected parameters, instead of exiting.
 
         currentMessages = [{ role: MESSAGE_ROLES.USER, parts: toolResponseParts }];
       } else {


### PR DESCRIPTION
## Summary / 摘要

修复非交互模式（`nonInteractiveCli`）中工具调用失败时直接 `process.exit(1)` 退出的问题，改为将错误作为 `functionResponse` 回传给 AI，使AI 有机会感知错误并重试。

Fix non-interactive mode (`nonInteractiveCli`) exiting immediately on tool call failure; instead return the error as a `functionResponse` so the AI can observe and retry with corrected parameters.

## Changes / 变更说明

- `packages/cli/src/nonInteractiveCli.ts`
  - 移除工具失败超过 2 次时调用 `process.exit(1)` 的逻辑
  - 移除"所有工具调用失败则退出"的兜底 `process.exit(1)` 逻辑
  - 将工具执行失败的结果封装为 `{ functionResponse: { name, response: { error } } }` 返回，让 AI 接收错误信息并决策下一步

## Testing / 测试

构造一个会触发工具调用失败的非交互请求（如调用不存在的工具或参数错误），验证进程不再直接退出，AI 收到错误响应后能继续推理并重试，最终正常完成任务。
