### PR TITLE
fix: add null check for base64 data URI split in image upload

### DIFF
--- a/packages/vscode-ui-plugin/src/extension.ts
+++ b/packages/vscode-ui-plugin/src/extension.ts
@@ -3048,7 +3048,11 @@ function setupMultiSessionHandlers() {
       const uploadResult = await imageGenerator.getUploadUrl(payload.filename, payload.contentType);
 
       // 2. 解析base64数据
-      const base64Data = payload.fileData.split(',')[1];
+      const parts = payload.fileData.split(',');
+      const base64Data = parts.length >= 2 ? parts[1] : payload.fileData;
+      if (!base64Data) {
+        throw new Error('Invalid base64 data URI: missing data after comma');
+      }
       const fileBuffer = Buffer.from(base64Data, 'base64');
 
       // 3. 上传图片到GCS


### PR DESCRIPTION
## Summary
`payload.fileData.split(',')[1]` returns `undefined` if the input doesn't contain a comma (e.g., raw base64 without data URI prefix). Passing `undefined` to `Buffer.from()` throws a TypeError at runtime.

Added a length check on the split result with a fallback to the full string, plus an explicit error for empty data.

## Test plan
- [ ] Standard data URI (`data:image/png;base64,iVBOR...`) still works
- [ ] Raw base64 string without prefix no longer crashes
- [ ] Empty data after comma throws descriptive error