### PR TITLE
fix(desktop): distinguish user messages from tool call cards

### DIFF
--- a/packages/desktop/src/renderer/src/styles/index.css
+++ b/packages/desktop/src/renderer/src/styles/index.css
@@ -706,13 +706,16 @@ select {
 }
 .msg-user {
   position: relative;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
+  background: var(--accent-weak);
+  border: 1px solid var(--accent-border);
   border-radius: var(--radius);
   padding: 12px 15px;
   white-space: pre-wrap;
   word-break: break-word;
   box-shadow: var(--shadow-sm);
+  /* Distinguish from tool cards: right-align the user's bubble so it reads
+     as an outgoing message, not another system-generated card. */
+  margin-left: 15%;
 }
 .msg-assistant {
   white-space: normal;


### PR DESCRIPTION
## Problem

User messages and tool call cards shared the identical background (--bg-elev), border (--border), and radius, making them visually indistinguishable in the transcript. Users could not tell at a glance which content was their own input vs a system-generated tool result.

## Fix

Give user messages the accent palette (accent-weak background, accent-border) and a left margin so the bubble reads as an outgoing message. Tool cards keep the neutral elevated background.

Before:
- User message: bg-elev + border (grey, full-width)
- Tool card: bg-elev + border (grey, full-width)

After:
- User message: accent-weak + accent-border (warm orange tint, indented right)
- Tool card: bg-elev + border (grey, full-width) — unchanged

## Verification

- [x] User messages have warm accent tint, visually distinct from tool cards
- [x] Tool cards retain neutral grey appearance
- [x] Works in both dark and light themes (uses CSS variables)
- [x] No layout shift or overflow

## Files Changed

- packages/desktop/src/renderer/src/styles/index.css (+5, -2)