### PR TITLE
docs: 修复 Star History 图表，恢复项目星标数据展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,7 +1304,7 @@ easycode -y
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OrionStarAI/EasyCodeCode&type=date&legend=top-left)](https://www.star-history.com/#OrionStarAI/EasyCodeCode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OrionStarAI/EasyCodeCode&type=date&legend=top-left)](https://star-history.dera.page/#OrionStarAI/EasyCodeCode&type=date&legend=top-left)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -597,7 +597,7 @@ If you find bugs or have feature suggestions, please [create an Issue](https://g
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OrionStarAI/EasyCodeCode&type=date&legend=top-left)](https://www.star-history.com/#OrionStarAI/EasyCodeCode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OrionStarAI/EasyCodeCode&type=date&legend=top-left)](https://star-history.dera.page/#OrionStarAI/EasyCodeCode&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已损坏，因 GitHub stargazer API 限制导致数据无法加载，影响项目星标数据的展示。

本 PR 将 README.md 与 README_EN.md 中的 Star History 图表图片地址和跳转链接更新为可正常工作的新服务地址，同时保留原有 repos 与展示参数，使图表恢复可用。

请尽快合并，以便社区能够正常看到项目的星标趋势。